### PR TITLE
Commands + bug fixes

### DIFF
--- a/src/main/java/uk/hotten/herobrine/HerobrinePluginOG.java
+++ b/src/main/java/uk/hotten/herobrine/HerobrinePluginOG.java
@@ -2,6 +2,8 @@ package uk.hotten.herobrine;
 
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
+import uk.hotten.herobrine.commands.ForceStartCommand;
+import uk.hotten.herobrine.commands.SetHerobrineCommand;
 import uk.hotten.herobrine.data.SqlManager;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.data.RedisManager;
@@ -26,6 +28,9 @@ public class HerobrinePluginOG extends JavaPlugin {
         WorldManager worldManager = new WorldManager(this);
         GameManager gameManager = new GameManager(this, worldManager, redisManager, protocolManager);
         StatManager statManager = new StatManager(this, gameManager);
+
+        getCommand("setherobrine").setExecutor(new SetHerobrineCommand());
+        getCommand("forcestart").setExecutor(new ForceStartCommand());
 
         Console.info("The Herobrine! is ready.");
     }

--- a/src/main/java/uk/hotten/herobrine/commands/ForceStartCommand.java
+++ b/src/main/java/uk/hotten/herobrine/commands/ForceStartCommand.java
@@ -1,0 +1,44 @@
+package uk.hotten.herobrine.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import uk.hotten.herobrine.game.GameManager;
+import uk.hotten.herobrine.game.runnables.StartingRunnable;
+import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
+
+public class ForceStartCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        GameManager gm = GameManager.get();
+
+        if (gm.getGameState() != GameState.WAITING) {
+            sender.sendMessage(Message.format(ChatColor.RED + "You cannot run this command right now."));
+            return true;
+        }
+
+        int startTime;
+        if (args == null || args.length == 0) {
+            startTime = 10;
+        } else {
+            try {
+                startTime = Integer.parseInt(args[0]);
+            } catch (Exception e) {
+                sender.sendMessage(Message.format(ChatColor.RED + "Correct Usage: /forcestart [time]"));
+                return true;
+            }
+        }
+
+        if (startTime < 10)
+            startTime = 10;
+
+        sender.sendMessage(Message.format(ChatColor.GREEN + "The game will start in " + startTime + " seconds unless the player count goes below 2."));
+        gm.startTimer = startTime+1;
+        gm.setGameState(GameState.STARTING);
+        new StartingRunnable(true).runTaskTimerAsynchronously(gm.getPlugin(), 0, 20);
+        return true;
+    }
+}

--- a/src/main/java/uk/hotten/herobrine/commands/SetHerobrineCommand.java
+++ b/src/main/java/uk/hotten/herobrine/commands/SetHerobrineCommand.java
@@ -1,0 +1,45 @@
+package uk.hotten.herobrine.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import uk.hotten.herobrine.game.GameManager;
+import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
+
+public class SetHerobrineCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        GameManager gm = GameManager.get();
+
+        if (gm.getGameState() != GameState.WAITING && gm.getGameState() != GameState.STARTING) {
+            sender.sendMessage(Message.format(ChatColor.RED + "You cannot run this command right now."));
+            return true;
+        }
+
+        if (args == null || args.length == 0) {
+            if (gm.getPassUser() == null)
+                sender.sendMessage(Message.format(ChatColor.RED + "Correct Usage: /setherobrine <player>"));
+            else {
+                sender.sendMessage(Message.format(ChatColor.GOLD + gm.getPassUser().getName() + " will no-longer be Herobrine."));
+                gm.setPassUser(null);
+            }
+            return true;
+        }
+
+        Player player = Bukkit.getPlayer(args[0]);
+
+        if (player == null) {
+            sender.sendMessage(Message.format(ChatColor.RED + args[0] + " is not online."));
+            return true;
+        }
+
+        gm.setPassUser(player);
+        sender.sendMessage(Message.format(ChatColor.YELLOW + player.getName() + " will be Herobrine."));
+        return true;
+    }
+}

--- a/src/main/java/uk/hotten/herobrine/game/GMListener.java
+++ b/src/main/java/uk/hotten/herobrine/game/GMListener.java
@@ -69,6 +69,12 @@ public class GMListener implements Listener {
             }
 
             gm.endCheck();
+            return;
+        }
+
+        if (gm.getPassUser() == event.getPlayer()) {
+            gm.setPassUser(null);
+            Message.broadcast(Message.format(ChatColor.GOLD + event.getPlayer().getName() + " has left and will no-longer be Herobrine."), "theherobrine.command.setherobrine");
         }
     }
 

--- a/src/main/java/uk/hotten/herobrine/game/GameManager.java
+++ b/src/main/java/uk/hotten/herobrine/game/GameManager.java
@@ -58,12 +58,12 @@ public class GameManager {
     private BlindingAbility hbBlinding;
     @Getter private ArrayList<Player> survivors;
     @Getter private ArrayList<Player> spectators;
-    @Getter private Player passUser;
+    @Getter @Setter private Player passUser;
 
     @Getter public int shardCount;
     @Getter @Setter private Player shardCarrier;
 
-    public int startTimer = 15; //todo set to 90
+    public int startTimer;
     public boolean stAlmost = false;
     public boolean stFull = false;
 
@@ -87,6 +87,7 @@ public class GameManager {
 
         requiredToStart = plugin.getConfig().getInt("minPlayers");
         maxPlayers = plugin.getConfig().getInt("maxPlayers");
+        startTimer = plugin.getConfig().getInt("startTime");
         allowOverfill = plugin.getConfig().getBoolean("allowOverfill");
         networkName = plugin.getConfig().getString("networkName");
 
@@ -150,6 +151,12 @@ public class GameManager {
 
     public void startWaiting() {
         setGameState(GameState.WAITING);
+
+        // In case the timer decreased from players leaving and a world was loaded
+        Bukkit.getServer().getScheduler().runTask(plugin, () -> WorldManager.getInstance().clean(false));
+        startTimer = plugin.getConfig().getInt("startTime");
+
+
         new WaitingRunnable().runTaskTimerAsynchronously(plugin, 0, 10);
     }
 

--- a/src/main/java/uk/hotten/herobrine/game/runnables/StartingRunnable.java
+++ b/src/main/java/uk/hotten/herobrine/game/runnables/StartingRunnable.java
@@ -12,11 +12,21 @@ import org.bukkit.scheduler.BukkitRunnable;
 
 public class StartingRunnable extends BukkitRunnable {
 
+    boolean ignorePlayerCount;
+
+    public StartingRunnable() {
+        ignorePlayerCount = false;
+    }
+
+    public StartingRunnable(boolean ignorePlayerCount) {
+        this.ignorePlayerCount = ignorePlayerCount;
+    }
+
     @Override
     public void run() {
         GameManager gm = GameManager.get();
 
-        if (gm.getRequiredToStart() > gm.getSurvivors().size()) {
+        if ((gm.getRequiredToStart() > gm.getSurvivors().size() && !ignorePlayerCount) || (ignorePlayerCount && gm.getSurvivors().size() <= 1)) {
             Message.broadcast(Message.format("" + ChatColor.RED + "Cancelled! Waiting for players..."));
             gm.startWaiting();
             cancel();

--- a/src/main/java/uk/hotten/herobrine/utils/Message.java
+++ b/src/main/java/uk/hotten/herobrine/utils/Message.java
@@ -18,6 +18,14 @@ public class Message {
         Bukkit.getServer().broadcastMessage(message);
     }
 
+    public static void broadcast(String message, String permission) {
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            if (p.hasPermission(permission)) {
+                p.sendMessage(message);
+            }
+        }
+    }
+
 
     public static String formatTime(int seconds) {
         if (seconds < 60)

--- a/src/main/java/uk/hotten/herobrine/world/WorldManager.java
+++ b/src/main/java/uk/hotten/herobrine/world/WorldManager.java
@@ -136,46 +136,44 @@ public class WorldManager implements Listener {
         gameWorld.setTime(18000);
 
 
-        Bukkit.getServer().getScheduler().runTaskLater(plugin, () -> {
-            // Load data points
-            File file = new File(map + "/mapdata.yaml");
-            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        // Load data points
+        File file = new File(map + "/mapdata.yaml");
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
-            try {
-                gameMapData = mapper.readValue(file, MapData.class);
-            } catch (Exception e) {
-                e.printStackTrace();
-                Console.error("Error parsing mapdata.yaml! Is it correctly formatted?");
-                return;
-            }
+        try {
+            gameMapData = mapper.readValue(file, MapData.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Console.error("Error parsing mapdata.yaml! Is it correctly formatted?");
+            return;
+        }
 
-            for (Datapoint dp : gameMapData.getDatapoints()) {
-                Location dLoc = new Location(gameWorld, dp.getX(), dp.getY(), dp.getZ());
-                switch (dp.getType()) {
-                    case SURVIVOR_SPAWN:
-                        survivorSpawn = dLoc;
-                        dLoc.getChunk().load(true);
-                        //dLoc.getChunk().setForceLoaded(true);
-                        noUnload.add(dLoc.getChunk());
-                        break;
-                    case HEROBRINE_SPAWN:
-                        herobrineSpawn = dLoc;
-                        dLoc.getChunk().load(true);
-                        //dLoc.getChunk().setForceLoaded(true);
-                        noUnload.add(dLoc.getChunk());
-                        break;
-                    case ALTER:
-                        alter = dLoc;
-                        break;
-                    case SHARD_SPAWN:
-                        shardSpawns.add(dLoc);
-                        break;
-                    default:
-                        break;
-                }
+        for (Datapoint dp : gameMapData.getDatapoints()) {
+            Location dLoc = new Location(gameWorld, dp.getX(), dp.getY(), dp.getZ());
+            switch (dp.getType()) {
+                case SURVIVOR_SPAWN:
+                    survivorSpawn = dLoc;
+                    dLoc.getChunk().load(true);
+                    //dLoc.getChunk().setForceLoaded(true);
+                    noUnload.add(dLoc.getChunk());
+                    break;
+                case HEROBRINE_SPAWN:
+                    herobrineSpawn = dLoc;
+                    dLoc.getChunk().load(true);
+                    //dLoc.getChunk().setForceLoaded(true);
+                    noUnload.add(dLoc.getChunk());
+                    break;
+                case ALTER:
+                    alter = dLoc;
+                    break;
+                case SHARD_SPAWN:
+                    shardSpawns.add(dLoc);
+                    break;
+                default:
+                    break;
             }
-            Console.info("Finished parsing!");
-        }, 50);
+        }
+        Console.info("Finished parsing!");
     }
 
     @EventHandler
@@ -188,7 +186,9 @@ public class WorldManager implements Listener {
             }, 100);
     }
 
-    public void clean() {
+    public void clean() { clean(true); }
+
+    public void clean(boolean clearVotes) {
         if (gameWorld != null) {
             Console.info("Cleaning the map...");
             for (Player p : Bukkit.getServer().getOnlinePlayers()) {
@@ -207,12 +207,13 @@ public class WorldManager implements Listener {
 
             gameWorld = null;
             gameMapData = null;
-            votingMaps = new HashMap<>();
             survivorSpawn = null;
             herobrineSpawn = null;
             alter = null;
             shardSpawns = new ArrayList<>();
             noUnload = new ArrayList<>();
+            if (clearVotes)
+                votingMaps = new HashMap<>();
             Console.info("Cleaned!");
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,7 @@ networkName: TrueOG # Name of your network
 networkWeb: trueog.net # Website of your network
 minPlayers: 2 # Minimum players needed to start a game
 maxPlayers: 16 # Maximum players in a game
+startTime: 15 # How many seconds till the game will start when the minimum is reached
 allowOverflow: false # Allow more than the max players to join
 mapBase: "maps" # Folder where the map base and maps folder is.
 votingMaps: 3 # How many maps should be chosen for players to vote on. Don't go over the amount of maps you have

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,19 @@
 name: TheHerobrine-OG
 main: uk.hotten.herobrine.HerobrinePluginOG
-version: PRE-1.0-master
+version: PRE-1.0-commands
 api-version: 1.18
 author: Gxorge
 description: Remake of "The Herobrine!" v2 from HiveMC.
 depend:
   - ProtocolLib
+
+commands:
+  setherobrine:
+    description: Select a player to be Herobrine.
+    permission: theherobrine.command.setherobrine
+    usage: /<command> <player>
+
+  forcestart:
+    description: Force start the game.
+    permission: theherobrine.command.forcestart
+    usage: /<command> [time]


### PR DESCRIPTION
- Force start command
- Set herobrine command

- The start time when the minimum players reached is now configurable
- The start time is reset if the minimum players is no longer met
- If the start timer cancels and a world was loaded, the vote is resumed and the world is unloaded

- World manager no longer waits 50 ticks before parsing the data points on a loaded world, I am not sure why it was like that
- Clean function can now take an argument on clearing the map votes, defaults to true