### PR TITLE
Version 1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "uk.hotten.herobrine"
-version = "1.1"
+version = "1.2"
 
 repositories {
     mavenLocal()

--- a/src/main/java/uk/hotten/herobrine/game/GMListener.java
+++ b/src/main/java/uk/hotten/herobrine/game/GMListener.java
@@ -141,7 +141,8 @@ public class GMListener implements Listener {
                 ShardHandler.drop(player.getLocation());
             }
 
-            gm.endCheck();
+            // If ran straight away, it still thinks THB is online if they were the quitter
+            Bukkit.getServer().getScheduler().runTaskLater(gm.getPlugin(), gm::endCheck, 1);
             return;
         }
 

--- a/src/main/java/uk/hotten/herobrine/game/GameManager.java
+++ b/src/main/java/uk/hotten/herobrine/game/GameManager.java
@@ -398,11 +398,12 @@ public class GameManager {
             });
         } else {
             PlayerUtil.broadcastTitle(ChatColor.RED + "HEROBRINE" + ChatColor.GREEN + " WINS!", "", 20, 60, 20);
-            Message.broadcast(Message.format("" + ChatColor.RED + ChatColor.BOLD + "The Herobrine " + ChatColor.YELLOW + "has defeated all the survivors"));
+            Message.broadcast(Message.format("" + ChatColor.RED + ChatColor.BOLD + "The Herobrine " + ChatColor.YELLOW + "has defeated all the survivors."));
             Message.broadcast(Message.format(type.getDesc()));
             PlayerUtil.broadcastSound(Sound.ENTITY_ENDER_DRAGON_HURT, 1f, 1f);
             StatManager.get().getPointsTracker().increment(herobrine.getUniqueId(), 10);
         }
+
         StatManager.get().stopTracking();
         StatManager.get().push();
         Message.broadcast(Message.format(ChatColor.GRAY + "The lobby will restart in 15 seconds."));
@@ -410,6 +411,11 @@ public class GameManager {
     }
 
     public void endCheck() {
+        Console.debug("=== END CHECK ===");
+        Console.debug("Survivors: " + getSurvivors().size());
+        Console.debug("Herobrine: " + (getHerobrine().isOnline() ? "Online" : "Offline"));
+        Console.debug("======");
+
         if (getSurvivors().size() == 0) {
             end(WinType.HEROBRINE);
         } else if (!getHerobrine().isOnline()) {
@@ -425,6 +431,7 @@ public class GameManager {
         if (shardCount == 3) {
             setShardState(ShardState.INACTIVE);
             herobrine.removePotionEffect(PotionEffectType.INVISIBILITY);
+            updateTags(ScoreboardUpdateAction.UPDATE);
         }
         else
             setShardState(ShardState.WAITING);
@@ -576,7 +583,7 @@ public class GameManager {
         for (Scoreboard s : getScoreboards().values()) {
             org.bukkit.scoreboard.Scoreboard sc = s.getHolder().getScoreboard();
 
-            String teamName = "APL" /*stands for  A PLAYER. e.g. npcs will be BNPC (gabi lied, she never made this a thing)*/ + player.getEntityId();
+            String teamName = "APL" + player.getEntityId();
             if (sc.getTeam(teamName) == null) {
                 sc.registerNewTeam(teamName);
             }
@@ -584,7 +591,12 @@ public class GameManager {
             Team team = sc.getTeam(teamName);
             team.setPrefix(prefix);
             team.setColor(color);
-            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS);
+            if (player == herobrine && shardCount == 3)
+                team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS);
+            else if (player == herobrine)
+                team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+            else
+                team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS);
 
             switch (action) {
                 case CREATE:
@@ -596,7 +608,12 @@ public class GameManager {
                     team = sc.getTeam(teamName);
                     team.setPrefix(prefix);
                     team.setColor(color);
-                    team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS);
+                    if (player == herobrine && shardCount == 3)
+                        team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS);
+                    else if (player == herobrine)
+                        team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                    else
+                        team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS);
                     team.addEntry(player.getName());
                     break;
                 case BEGONETHOT:

--- a/src/main/java/uk/hotten/herobrine/stat/GameRank.java
+++ b/src/main/java/uk/hotten/herobrine/stat/GameRank.java
@@ -20,7 +20,7 @@ public enum GameRank {
     PARANORMAL(ChatColor.BLUE + "Paranormal", 45000, 59999),
     SPECTRAL(ChatColor.DARK_GREEN + "Spectral", 60000, 79999),
     MYTHICAL(ChatColor.GOLD + "Mythical", 80000, 99999),
-    GHOSTBUSTER(ChatColor.GRAY + "GhostBuster", 100000, 149999),
+    GHOSTBUSTER(ChatColor.WHITE + "GhostBuster", 100000, 149999),
     SPOOKY("" + ChatColor.DARK_PURPLE + ChatColor.BOLD + "Spooky", 150000, 199999),
     ETHEREAL("" + ChatColor.RED + ChatColor.BOLD + "Ethereal", 200000, 249999),
     DEMONHUNTER("" + ChatColor.GRAY + ChatColor.BOLD + "DemonHunter", 250000, 299999),

--- a/src/main/java/uk/hotten/herobrine/stat/StatTracker.java
+++ b/src/main/java/uk/hotten/herobrine/stat/StatTracker.java
@@ -29,12 +29,9 @@ public class StatTracker implements Listener {
         stat = new HashMap<>();
     }
 
-    public void start() { Bukkit.getServer().getPluginManager().registerEvents(this, GameManager.get().getPlugin()); }
-
-    public void reset() {
-        HandlerList.unregisterAll(this);
-        stat.clear();
-    }
+    public void start() { Console.debug(displayName + " tracking STARTED."); Bukkit.getServer().getPluginManager().registerEvents(this, GameManager.get().getPlugin()); }
+    public void stop() { Console.debug(displayName + " tracking STOPPED."); HandlerList.unregisterAll(this); }
+    public void reset() { Console.debug(displayName + " tracking RESET."); stat.clear(); }
 
     public void increment(UUID uuid, int by) {
         if (!stat.containsKey(uuid)) {

--- a/src/main/java/uk/hotten/herobrine/stat/trackers/DeathTracker.java
+++ b/src/main/java/uk/hotten/herobrine/stat/trackers/DeathTracker.java
@@ -1,5 +1,6 @@
 package uk.hotten.herobrine.stat.trackers;
 
+import org.bukkit.event.player.PlayerQuitEvent;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.stat.StatManager;
 import uk.hotten.herobrine.stat.StatTracker;
@@ -18,6 +19,18 @@ public class DeathTracker extends StatTracker {
     @EventHandler(priority = EventPriority.LOWEST)
     public void death(PlayerDeathEvent event) {
         Player player = event.getEntity();
+
+        GameManager gm = GameManager.get();
+        if (gm.getGameState() != GameState.LIVE)
+            return;
+
+        if (gm.getSurvivors().contains(player) || gm.getHerobrine() == player)
+            increment(player.getUniqueId(), 1);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
 
         GameManager gm = GameManager.get();
         if (gm.getGameState() != GameState.LIVE)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,7 @@ endVotingAt: 10 # Stops the vote at the set remaining seconds until the game sta
 
 lockClassicKits: false # Do you want to lock classic kits such as Archer and Scout behind their permission?
 lockUnlockableKits: true # Do you want to lock unlockable kits such as Mage and Sorcerer behind their permission?
+showDeathBringerAt: 100000 # How many points must the top player surpass for the Death Bringer rank to show?
 
 showDebugMessages: false # Show debug messages?
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: TheHerobrine-OG
 main: uk.hotten.herobrine.HerobrinePluginOG
-version: 1.1
+version: 1.2
 api-version: 1.18
 author: Gxorge
 description: Remake of "The Herobrine!" v2 from HiveMC.


### PR DESCRIPTION
Version 1.2 has the following new features and bug fixes:

Game Manager
- End check debug messages
- Fixed HB leaving not causing the game to end
- Fixed a bug found in 1.8 where the nametag of a player with invis still shows

Stat Manager
- Fixed stats not pushing
- Separated tracking stopping and resetting, along with adding debug messages
- Added a config option to set the threshold of which the Death Bringer rank can show up
- Players quitting now count as deaths
- Fixed GhostBuster's rank to be white rather than grey.