### PR TITLE
Core Version 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "uk.hotten.herobrine"
-version = "1.2"
+version = "1.3"
 
 repositories {
     mavenLocal()
@@ -44,7 +44,7 @@ dependencies {
     compileOnly 'com.comphenix.protocol:ProtocolLib:4.7.0'
     compileOnly 'org.projectlombok:lombok:1.18.22'
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
-    implementation 'uk.hotten.gxui:GxUI:1.2'
+    implementation 'uk.hotten.gxui:GxUI:1.2.1'
 }
 
 tasks.register('updatePluginYmlVersion') {

--- a/src/main/java/uk/hotten/herobrine/HerobrinePluginOG.java
+++ b/src/main/java/uk/hotten/herobrine/HerobrinePluginOG.java
@@ -7,10 +7,7 @@ import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketEvent;
 import me.tigerhix.lib.scoreboard.ScoreboardLib;
 import org.bukkit.Sound;
-import uk.hotten.herobrine.commands.DropShardCommand;
-import uk.hotten.herobrine.commands.ForceStartCommand;
-import uk.hotten.herobrine.commands.SetHerobrineCommand;
-import uk.hotten.herobrine.commands.VoteCommand;
+import uk.hotten.herobrine.commands.*;
 import uk.hotten.herobrine.data.SqlManager;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.data.RedisManager;
@@ -41,6 +38,7 @@ public class HerobrinePluginOG extends JavaPlugin {
         getCommand("setherobrine").setExecutor(new SetHerobrineCommand());
         getCommand("forcestart").setExecutor(new ForceStartCommand());
         getCommand("dropshard").setExecutor(new DropShardCommand());
+        getCommand("pausetimer").setExecutor(new PauseTimerCommand());
         getCommand("vote").setExecutor(new VoteCommand());
 
         // Stops the eye of ender break SFX from the Notch's Wisdom and Totem of Healing abilities

--- a/src/main/java/uk/hotten/herobrine/commands/PauseTimerCommand.java
+++ b/src/main/java/uk/hotten/herobrine/commands/PauseTimerCommand.java
@@ -1,0 +1,35 @@
+package uk.hotten.herobrine.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import uk.hotten.herobrine.game.GameManager;
+import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
+
+public class PauseTimerCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        GameManager gm = GameManager.get();
+
+        if (gm.getGameState() != GameState.WAITING && gm.getGameState() != GameState.STARTING) {
+            sender.sendMessage(Message.format(ChatColor.RED + "You cannot run this command right now."));
+            return true;
+        }
+
+        if (!gm.timerPaused) {
+            sender.sendMessage(Message.format("The timer has been paused."));
+            // If the timer was running, the starting runnable will stop it.
+        } else {
+            sender.sendMessage(Message.format("The timer has been un-paused."));
+            // Start check occurs below to restart the timer if there is enough players
+        }
+
+        gm.timerPaused = !gm.timerPaused;
+        gm.startCheck(); // This will check the pause status, so it won't run if the timer has been paused.
+
+        return true;
+    }
+}

--- a/src/main/java/uk/hotten/herobrine/commands/VoteCommand.java
+++ b/src/main/java/uk/hotten/herobrine/commands/VoteCommand.java
@@ -57,7 +57,7 @@ public class VoteCommand implements CommandExecutor {
             wm.getPlayerVotes().remove(player);
             wm.getPlayerVotes().put(player, map);
             wm.getVotingMaps().get(map).incrementVotes();
-            player.sendMessage(Message.format(ChatColor.GOLD + "Vote for received. " + ChatColor.AQUA + wm.getVotingMaps().get(map).getMapData().getName() + ChatColor.GOLD + " now has " + ChatColor.AQUA + wm.getVotingMaps().get(map).getVotes() + ChatColor.GOLD + " votes."));
+            player.sendMessage(Message.format(ChatColor.GOLD + "Vote received. " + ChatColor.AQUA + wm.getVotingMaps().get(map).getMapData().getName() + ChatColor.GOLD + " now has " + ChatColor.AQUA + wm.getVotingMaps().get(map).getVotes() + ChatColor.GOLD + " votes."));
         }
 
         return true;

--- a/src/main/java/uk/hotten/herobrine/game/GMListener.java
+++ b/src/main/java/uk/hotten/herobrine/game/GMListener.java
@@ -86,22 +86,7 @@ public class GMListener implements Listener {
 
         Message.broadcast(Message.format("" + ChatColor.AQUA + player.getName() + " " + ChatColor.YELLOW + "has joined!"));
         gm.getSurvivors().add(player);
-        if (gm.getSurvivors().size() >= gm.getRequiredToStart()) {
-            if (gm.getGameState() != GameState.STARTING) {
-                gm.setGameState(GameState.STARTING);
-                new StartingRunnable().runTaskTimerAsynchronously(gm.getPlugin(), 0, 20);
-            } else {
-                if (gm.getSurvivors().size() >= gm.getMaxPlayers()-3 && !gm.stAlmost && gm.startTimer > 30) {
-                    Message.broadcast(Message.format("" + ChatColor.GREEN + "We almost have a full server! Shortening timer to 30 seconds!"));
-                    gm.stAlmost = true;
-                    gm.startTimer = 30;
-                } else if (gm.getSurvivors().size() >= gm.getMaxPlayers() && !gm.stFull && gm.startTimer > 10) {
-                    Message.broadcast(Message.format("" + ChatColor.GREEN + "We have a full server! Starting in 10 seconds!"));
-                    gm.stFull = true;
-                    gm.startTimer = 10;
-                }
-            }
-        }
+        gm.startCheck();
 
         WorldManager.getInstance().getPlayerVotes().put(player, 0);
         WorldManager.getInstance().sendVotingMessage(player);

--- a/src/main/java/uk/hotten/herobrine/game/runnables/HerobrineSmokeRunnable.java
+++ b/src/main/java/uk/hotten/herobrine/game/runnables/HerobrineSmokeRunnable.java
@@ -1,5 +1,7 @@
 package uk.hotten.herobrine.game.runnables;
 
+import org.bukkit.Effect;
+import org.bukkit.block.BlockFace;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.utils.GameState;
 import org.bukkit.Bukkit;
@@ -19,8 +21,7 @@ public class HerobrineSmokeRunnable extends BukkitRunnable {
             return;
         }
 
-        Location loc = gm.getHerobrine().getLocation().clone().add(0, 1, 0);
-        ParticleEffect.SMOKE_LARGE.display(loc, new Vector(0, 0, 0), 3f, 0, null, Bukkit.getServer().getOnlinePlayers());
-        ParticleEffect.SMOKE_LARGE.display(loc, new Vector(0, 0, 0), 3f, 0, null, Bukkit.getServer().getOnlinePlayers());
+        Location loc = gm.getHerobrine().getLocation().clone().add(0, 2, 0);
+        loc.getWorld().playEffect(loc, Effect.SMOKE, 0);
     }
 }

--- a/src/main/java/uk/hotten/herobrine/game/runnables/StartingRunnable.java
+++ b/src/main/java/uk/hotten/herobrine/game/runnables/StartingRunnable.java
@@ -26,7 +26,14 @@ public class StartingRunnable extends BukkitRunnable {
         GameManager gm = GameManager.get();
 
         if ((gm.getRequiredToStart() > gm.getSurvivors().size() && !ignorePlayerCount) || (ignorePlayerCount && gm.getSurvivors().size() <= 1)) {
-            Message.broadcast(Message.format("" + ChatColor.RED + "Cancelled! Waiting for players..."));
+            Message.broadcast(Message.format("" + ChatColor.RED + "Start cancelled! Waiting for players..."));
+            gm.startWaiting();
+            cancel();
+            return;
+        }
+
+        if (gm.timerPaused) {
+            Message.broadcast(Message.format("" + ChatColor.RED + "Start cancelled! Waiting for server operator..."));
             gm.startWaiting();
             cancel();
             return;

--- a/src/main/java/uk/hotten/herobrine/game/runnables/WaitingRunnable.java
+++ b/src/main/java/uk/hotten/herobrine/game/runnables/WaitingRunnable.java
@@ -21,7 +21,10 @@ public class WaitingRunnable extends BukkitRunnable {
 
         if (time <= 4.5) {
             int required = GameManager.get().getRequiredToStart() - GameManager.get().getSurvivors().size();
-            PlayerUtil.broadcastActionbar("" + ChatColor.YELLOW + "Waiting for " + ChatColor.AQUA + required + ChatColor.YELLOW + " player" + (required == 1 ? "" : "s"));
+            if (!GameManager.get().timerPaused)
+                PlayerUtil.broadcastActionbar("" + ChatColor.YELLOW + "Waiting for " + ChatColor.AQUA + required + ChatColor.YELLOW + " player" + (required == 1 ? "" : "s"));
+            else
+                PlayerUtil.broadcastActionbar(ChatColor.RED + "Waiting for server operator");
         } else if (time == 5 || time == 6 || time == 6.5) {
             PlayerUtil.broadcastActionbar(ChatColor.AQUA + "Playing " + ChatColor.GRAY + "» " + ChatColor.YELLOW + "TheHerobrine");
         } else if (time == 7 || time == 8 || time == 8.5) {

--- a/src/main/java/uk/hotten/herobrine/kit/Kit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/Kit.java
@@ -21,11 +21,11 @@ public abstract class Kit implements Listener {
     @Getter private String displayName;
     @Getter private String permission;
     @Getter private boolean requirePermission;
-    @Getter private String desc;
+    @Getter private ArrayList<String> desc;
     @Getter private GUIItem displayItem;
     public HashMap<Player, ArrayList<KitAbility>> abilities;
 
-    public Kit(GameManager gm, String internalName, String displayName, String permission, boolean requirePermission, String desc, GUIItem displayItem) {
+    public Kit(GameManager gm, String internalName, String displayName, String permission, boolean requirePermission, ArrayList<String> desc, GUIItem displayItem) {
         this.gm = gm;
 
         this.internalName = internalName;

--- a/src/main/java/uk/hotten/herobrine/kit/KitGui.java
+++ b/src/main/java/uk/hotten/herobrine/kit/KitGui.java
@@ -14,7 +14,7 @@ public class KitGui extends GUIBase {
     private Player assignedPlayer;
 
     public KitGui(JavaPlugin plugin, Player player) {
-        super(plugin, player, ChatColor.GRAY + "Pick your class", 9, false);
+        super(plugin, player, ChatColor.DARK_GRAY + "Pick your class", 9, false);
         assignedPlayer = player;
     }
 
@@ -24,10 +24,10 @@ public class KitGui extends GUIBase {
         int curr = 0;
         for (Kit kit : gm.getKits()) {
             GUIItem item = kit.getDisplayItem().duplicateByConstructor();
+            item.lore(kit.getDesc());
             item.button(new GUIButton() {
                 @Override
                 public boolean leftClick() {
-                    System.out.println("Player is " + assignedPlayer);
                     if (kit.getPermission() == null || (!kit.isRequirePermission() || assignedPlayer.hasPermission(kit.getPermission()))) {
                         GameManager.get().setKit(assignedPlayer, kit, true);
                         assignedPlayer.closeInventory();

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/BatBombAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/BatBombAbility.java
@@ -4,6 +4,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -14,6 +15,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
 
 public class BatBombAbility extends KitAbility {
 
@@ -31,6 +34,8 @@ public class BatBombAbility extends KitAbility {
     public void apply(Player player) {
         this.player = player;
         GUIItem bomb = new GUIItem(Material.COAL).displayName(ChatColor.DARK_GREEN + "Bat Bomb").amount(amount);
+        bomb.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Launches a pack of exploding bats, don't let them kill you...", "" + ChatColor.GRAY + ChatColor.ITALIC));
+
         if (slot == -1)
             player.getInventory().addItem(bomb.build());
         else

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/BlindingAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/BlindingAbility.java
@@ -4,6 +4,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -31,6 +32,8 @@ public class BlindingAbility extends KitAbility {
     public void apply(Player player) {
         this.player = player;
         GUIItem charge = new GUIItem(Material.GOLD_NUGGET).displayName(ChatColor.GOLD + "Charge of " + ChatColor.BOLD + "Blinding!").amount(amount);
+        charge.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Launches a charge that blinds survivors within a 6 block radius", "" + ChatColor.GRAY + ChatColor.ITALIC));
+
         if (slot == -1)
             player.getInventory().addItem(charge.build());
         else

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/DreamweaverAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/DreamweaverAbility.java
@@ -4,6 +4,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -29,6 +30,7 @@ public class DreamweaverAbility extends KitAbility {
     public void apply(Player player) {
         this.player = player;
         GUIItem item = new GUIItem(Material.MAGMA_CREAM).displayName(ChatColor.GREEN + "Dreamweaver Bandage").amount(amount);
+        item.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Bandage yourself to full health", "" + ChatColor.GRAY + ChatColor.ITALIC));
 
         if (slot == -1)
             player.getInventory().addItem(item.build());

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/HarmingTotemAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/HarmingTotemAbility.java
@@ -10,6 +10,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 
 public class HarmingTotemAbility extends KitAbility {
 
@@ -24,7 +25,8 @@ public class HarmingTotemAbility extends KitAbility {
     @Override
     public void apply(Player player) {
         this.player = player;
-        GUIItem item = new GUIItem(Material.NETHER_BRICK_FENCE).displayName("" + ChatColor.YELLOW + ChatColor.BOLD + "Totem: " + ChatColor.GREEN + "Pain");
+        GUIItem item = new GUIItem(Material.NETHER_BRICK_FENCE).displayName("" + ChatColor.YELLOW + ChatColor.BOLD + "Totem: " + ChatColor.RED + "Pain");
+        item.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Creates an aura of pain to damage The Herobrine for 60 seconds", "" + ChatColor.GRAY + ChatColor.ITALIC));
 
         player.getInventory().setItem(slot, item.build());
     }

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/HealingTotemAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/HealingTotemAbility.java
@@ -10,6 +10,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 
 public class HealingTotemAbility extends KitAbility {
 
@@ -25,6 +26,7 @@ public class HealingTotemAbility extends KitAbility {
     public void apply(Player player) {
         this.player = player;
         GUIItem item = new GUIItem(Material.OAK_FENCE).displayName("" + ChatColor.YELLOW + ChatColor.BOLD + "Totem: " + ChatColor.GREEN + "Healing");
+        item.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Creates an aura of health to heal survivors for 60 seconds", "" + ChatColor.GRAY + ChatColor.ITALIC));
 
         player.getInventory().setItem(slot, item.build());
     }

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/LocatorAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/LocatorAbility.java
@@ -6,6 +6,7 @@ import uk.hotten.herobrine.kit.KitAbility;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import uk.hotten.herobrine.utils.Message;
 
 public class LocatorAbility extends KitAbility {
 
@@ -16,6 +17,7 @@ public class LocatorAbility extends KitAbility {
     @Override
     public void apply(Player player) {
         GUIItem item = new GUIItem(Material.COMPASS).displayName(ChatColor.GRAY + "Objective Locator");
+        item.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Use this to locate the shard and the alter", "" + ChatColor.GRAY + ChatColor.ITALIC));
 
         player.getInventory().setItem(8, item.build());
     }

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/LoveAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/LoveAbility.java
@@ -11,6 +11,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 
 public class LoveAbility extends KitAbility {
@@ -27,6 +28,7 @@ public class LoveAbility extends KitAbility {
     public void apply(Player player) {
         this.player = player;
         GUIItem item = new GUIItem(Material.FEATHER).displayName(ChatColor.RED + "Overwhelming " + ChatColor.BOLD + "Love");
+        item.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Heal all your survivors 3 hearts", "" + ChatColor.GRAY + ChatColor.ITALIC));
 
         if (slot == -1)
             player.getInventory().addItem(item.build());

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/ProtSpiritAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/ProtSpiritAbility.java
@@ -10,6 +10,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 
 public class ProtSpiritAbility extends KitAbility {
@@ -28,6 +29,7 @@ public class ProtSpiritAbility extends KitAbility {
     public void apply(Player player) {
         this.player = player;
         GUIItem item = new GUIItem(Material.ENDER_PEARL).displayName(ChatColor.AQUA + "Protection " + ChatColor.BOLD + "Spirit!").amount(amount);
+        item.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Protect yourself with a spirit of rapid healing for 12 seconds", "" + ChatColor.GRAY + ChatColor.ITALIC));
 
         player.getInventory().setItem(slot, item.build());
     }

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/ProtSpiritHandler.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/ProtSpiritHandler.java
@@ -3,6 +3,7 @@ package uk.hotten.herobrine.kit.abilities;
 import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.utils.PlayerUtil;
 
 import java.util.Random;
@@ -19,6 +20,11 @@ public class ProtSpiritHandler extends BukkitRunnable {
 
     @Override
     public void run() {
+        if (!GameManager.get().getSurvivors().contains(player)) {
+            cancel();
+            return;
+        }
+
         if (time > 24) {
             cancel();
             return;

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/WisdomAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/WisdomAbility.java
@@ -4,6 +4,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -28,6 +29,7 @@ public class WisdomAbility extends KitAbility {
     public void apply(Player player) {
         this.player = player;
         GUIItem wiz = new GUIItem(Material.BLAZE_POWDER).displayName(ChatColor.GREEN + "Notch's Wisdom").amount(amount);
+        wiz.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "Creates an aura of health to heal survivors for 10 seconds", "" + ChatColor.GRAY + ChatColor.ITALIC));
 
         player.getInventory().setItem(slot, wiz.build());
     }

--- a/src/main/java/uk/hotten/herobrine/kit/abilities/WooflessAbility.java
+++ b/src/main/java/uk/hotten/herobrine/kit/abilities/WooflessAbility.java
@@ -4,6 +4,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.KitAbility;
 import uk.hotten.herobrine.utils.GameState;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -30,6 +31,8 @@ public class WooflessAbility extends KitAbility {
         this.player = player;
 
         GUIItem bone = new GUIItem(Material.BONE).displayName(ChatColor.AQUA + "Summon Woofless");
+        bone.lore(Message.addLinebreaks("" + ChatColor.GRAY + ChatColor.ITALIC + "It's dangerous to go alone, take a friend!", "" + ChatColor.GRAY + ChatColor.ITALIC));
+
         player.getInventory().setItem(slot, bone.build());
     }
 

--- a/src/main/java/uk/hotten/herobrine/kit/kits/ArcherKit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/kits/ArcherKit.java
@@ -11,6 +11,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
+import uk.hotten.herobrine.utils.Message;
 
 public class ArcherKit extends Kit {
 
@@ -20,7 +21,12 @@ public class ArcherKit extends Kit {
                 ChatColor.GREEN + "Archer",
                 "theherobrine.kit.classic.archer",
                 requirePermission,
-                "",
+                Message.createArray(
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Hatchet of War" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (weapon)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.YELLOW + "Phoenix Bow" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (bow)",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GRAY + "Eagle Feather Quills" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x64)"
+                ),
                 new GUIItem(Material.BOW).displayName(ChatColor.GREEN + "Archer")
         );
     }
@@ -33,9 +39,9 @@ public class ArcherKit extends Kit {
     @Override
     public void setupPlayer(Player player) {
         // Items
-        GUIItem bow = new GUIItem(Material.BOW).displayName(ChatColor.YELLOW + "Phoenix Bow").enchantment(Enchantment.ARROW_KNOCKBACK, 1);
+        GUIItem bow = new GUIItem(Material.BOW).displayName(ChatColor.YELLOW + "Phoenix Bow").enchantment(Enchantment.ARROW_KNOCKBACK, 1).unbreakable(true);
         GUIItem arrow = new GUIItem(Material.ARROW).displayName(ChatColor.GRAY + "Eagle Feather Quills").amount(64);
-        GUIItem axe = new GUIItem(Material.IRON_AXE).displayName(ChatColor.GREEN + "Hatchet of War");
+        GUIItem axe = new GUIItem(Material.IRON_AXE).displayName(ChatColor.GREEN + "Hatchet of War").unbreakable(true);
 
         player.getInventory().setItem(0, bow.build());
         player.getInventory().setItem(1, arrow.build());
@@ -45,10 +51,11 @@ public class ArcherKit extends Kit {
         ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta helMeta = (LeatherArmorMeta) helmet.getItemMeta();
         helMeta.setColor(Color.GREEN);
+        helMeta.setUnbreakable(true);
         helmet.setItemMeta(helMeta);
         player.getInventory().setHelmet(helmet);
 
-        player.getInventory().setChestplate(new ItemStack(Material.CHAINMAIL_CHESTPLATE));
-        player.getInventory().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
+        player.getInventory().setChestplate(new GUIItem(Material.CHAINMAIL_CHESTPLATE).unbreakable(true).build());
+        player.getInventory().setBoots(new GUIItem(Material.CHAINMAIL_BOOTS).unbreakable(true).build());
     }
 }

--- a/src/main/java/uk/hotten/herobrine/kit/kits/MageKit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/kits/MageKit.java
@@ -14,6 +14,7 @@ import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.Kit;
 import uk.hotten.herobrine.kit.abilities.LocatorAbility;
 import uk.hotten.herobrine.kit.abilities.LoveAbility;
+import uk.hotten.herobrine.utils.Message;
 
 public class MageKit extends Kit {
 
@@ -23,7 +24,15 @@ public class MageKit extends Kit {
                 ChatColor.AQUA + "Mage",
                 "theherobrine.kit.unlockable.mage",
                 requirePermission,
-                "",
+                Message.createArray(
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GOLD + "Elder's Sword" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (weapon)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Water of " + ChatColor.BOLD + "Reckoning" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (bow)",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.AQUA + "Mana " + ChatColor.BOLD + "Arrow" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x32)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.RED + "Overwhelming " + ChatColor.BOLD + "Love" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x1)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Heal all your survivors 3 hearts"
+                ),
                 new GUIItem(Material.WOODEN_SWORD).displayName(ChatColor.AQUA + "Mage")
         );
     }
@@ -36,8 +45,8 @@ public class MageKit extends Kit {
 
     @Override
     public void setupPlayer(Player player) {
-        GUIItem sword = new GUIItem(Material.WOODEN_SWORD).displayName(ChatColor.GOLD + "Elder's Sword");
-        GUIItem bow = new GUIItem(Material.BOW).displayName(ChatColor.GREEN + "Water of " + ChatColor.BOLD + "Reckoning");
+        GUIItem sword = new GUIItem(Material.WOODEN_SWORD).displayName(ChatColor.GOLD + "Elder's Sword").unbreakable(true);
+        GUIItem bow = new GUIItem(Material.BOW).displayName(ChatColor.GREEN + "Water of " + ChatColor.BOLD + "Reckoning").unbreakable(true);
         GUIItem arrow = new GUIItem(Material.ARROW).displayName(ChatColor.AQUA + "Mana " + ChatColor.BOLD + "Arrow").amount(32);
 
         ItemStack healing = new ItemStack(Material.POTION);
@@ -55,11 +64,12 @@ public class MageKit extends Kit {
         ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta helMeta = (LeatherArmorMeta) helmet.getItemMeta();
         helMeta.setColor(Color.AQUA);
+        helMeta.setUnbreakable(true);
         helmet.setItemMeta(helMeta);
         player.getInventory().setHelmet(helmet);
 
-        player.getInventory().setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
-        player.getInventory().setLeggings(new ItemStack(Material.LEATHER_LEGGINGS));
-        player.getInventory().setBoots(new ItemStack(Material.LEATHER_BOOTS));
+        player.getInventory().setChestplate(new GUIItem(Material.LEATHER_CHESTPLATE).unbreakable(true).build());
+        player.getInventory().setLeggings(new GUIItem(Material.LEATHER_LEGGINGS).unbreakable(true).build());
+        player.getInventory().setBoots(new GUIItem(Material.LEATHER_BOOTS).unbreakable(true).build());
     }
 }

--- a/src/main/java/uk/hotten/herobrine/kit/kits/PaladinKit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/kits/PaladinKit.java
@@ -12,6 +12,7 @@ import uk.hotten.herobrine.kit.Kit;
 import uk.hotten.herobrine.kit.abilities.LocatorAbility;
 import uk.hotten.herobrine.kit.abilities.ProtSpiritAbility;
 import uk.hotten.herobrine.kit.abilities.WisdomAbility;
+import uk.hotten.herobrine.utils.Message;
 
 public class PaladinKit extends Kit {
 
@@ -21,7 +22,17 @@ public class PaladinKit extends Kit {
                 ChatColor.GOLD + "Paladin",
                 "theherobrine.kit.unlockable.paladin",
                 requirePermission,
-                "",
+                Message.createArray(
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Paladin's Might" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (weapon)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.AQUA + "Protection " + ChatColor.BOLD + "Spirit!" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x3)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Protect yourself with a spirit of",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "rapid healing for 12 seconds",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Notch's Wisdom" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x3)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Creates an aura of health to",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "heal survivors for 10 seconds"
+                ),
                 new GUIItem(Material.ENDER_PEARL).displayName(ChatColor.GOLD + "Paladin")
         );
     }
@@ -35,7 +46,7 @@ public class PaladinKit extends Kit {
 
     @Override
     public void setupPlayer(Player player) {
-        GUIItem sword = new GUIItem(Material.IRON_SWORD).displayName(ChatColor.GREEN + "Paladin's Might");
+        GUIItem sword = new GUIItem(Material.IRON_SWORD).displayName(ChatColor.GREEN + "Paladin's Might").unbreakable(true);
 
         player.getInventory().setItem(0, sword.build());
 
@@ -43,10 +54,11 @@ public class PaladinKit extends Kit {
         ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta helMeta = (LeatherArmorMeta) helmet.getItemMeta();
         helMeta.setColor(Color.ORANGE);
+        helMeta.setUnbreakable(true);
         helmet.setItemMeta(helMeta);
         player.getInventory().setHelmet(helmet);
 
-        player.getInventory().setChestplate(new ItemStack(Material.CHAINMAIL_CHESTPLATE));
-        player.getInventory().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
+        player.getInventory().setChestplate(new GUIItem(Material.CHAINMAIL_CHESTPLATE).unbreakable(true).build());
+        player.getInventory().setBoots(new GUIItem(Material.CHAINMAIL_BOOTS).unbreakable(true).build());
     }
 }

--- a/src/main/java/uk/hotten/herobrine/kit/kits/PriestKit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/kits/PriestKit.java
@@ -13,6 +13,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
+import uk.hotten.herobrine.utils.Message;
 
 public class PriestKit extends Kit {
 
@@ -22,7 +23,19 @@ public class PriestKit extends Kit {
                 ChatColor.WHITE + "Priest",
                 "theherobrine.kit.classic.priest",
                 requirePermission,
-                "",
+                Message.createArray(
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Blade of Heroism" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (weapon)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Dreamweaver Bandage" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x2)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Bandage yourself to full health",
+                        "   ",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Notch's Wisdom" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x2)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Creates an aura of health to",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "heal survivors for 10 seconds",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.AQUA + "Summon Woofless" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x1)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "It's dangerous to go alone, take a friend!"
+                ),
                 new GUIItem(Material.BONE).displayName(ChatColor.WHITE + "Priest")
         );
     }
@@ -38,7 +51,7 @@ public class PriestKit extends Kit {
     @Override
     public void setupPlayer(Player player) {
         // Items
-        GUIItem blade = new GUIItem(Material.STONE_SWORD).displayName(ChatColor.GREEN + "Blade of Heroism");
+        GUIItem blade = new GUIItem(Material.STONE_SWORD).displayName(ChatColor.GREEN + "Blade of Heroism").unbreakable(true);
 
         player.getInventory().setItem(0, blade.build());
 
@@ -46,11 +59,12 @@ public class PriestKit extends Kit {
         ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta helMeta = (LeatherArmorMeta) helmet.getItemMeta();
         helMeta.setColor(Color.WHITE);
+        helMeta.setUnbreakable(true);
         helmet.setItemMeta(helMeta);
         player.getInventory().setHelmet(helmet);
 
-        player.getInventory().setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
-        player.getInventory().setLeggings(new ItemStack(Material.LEATHER_LEGGINGS));
-        player.getInventory().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
+        player.getInventory().setChestplate(new GUIItem(Material.LEATHER_CHESTPLATE).unbreakable(true).build());
+        player.getInventory().setLeggings(new GUIItem(Material.LEATHER_LEGGINGS).unbreakable(true).build());
+        player.getInventory().setBoots(new GUIItem(Material.CHAINMAIL_BOOTS).unbreakable(true).build());
     }
 }

--- a/src/main/java/uk/hotten/herobrine/kit/kits/ScoutKit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/kits/ScoutKit.java
@@ -4,6 +4,7 @@ import uk.hotten.gxui.GUIItem;
 import uk.hotten.herobrine.game.GameManager;
 import uk.hotten.herobrine.kit.Kit;
 import uk.hotten.herobrine.kit.abilities.LocatorAbility;
+import uk.hotten.herobrine.utils.Message;
 import uk.hotten.herobrine.utils.PlayerUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -21,7 +22,14 @@ public class ScoutKit extends Kit {
                 ChatColor.YELLOW + "Scout",
                 "theherobrine.kit.classic.scout",
                 requirePermission,
-                "",
+                Message.createArray(
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Blade of Heroism" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (weapon)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GRAY + "Handcrafted Bow" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (bow)",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GRAY + "Owl Arrows" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x32)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.AQUA + "Speed I"
+                ),
                 new GUIItem(Material.FEATHER).displayName(ChatColor.YELLOW + "Scout")
         );
     }
@@ -37,8 +45,8 @@ public class ScoutKit extends Kit {
         PlayerUtil.addEffect(player, PotionEffectType.SPEED, Integer.MAX_VALUE, 0, false, false);
 
         // Items
-        GUIItem blade = new GUIItem(Material.STONE_SWORD).displayName(ChatColor.GREEN + "Blade of Heroism");
-        GUIItem bow = new GUIItem(Material.BOW).displayName(ChatColor.GRAY + "Handcrafted Bow");
+        GUIItem blade = new GUIItem(Material.STONE_SWORD).displayName(ChatColor.GREEN + "Blade of Heroism").unbreakable(true);
+        GUIItem bow = new GUIItem(Material.BOW).displayName(ChatColor.GRAY + "Handcrafted Bow").unbreakable(true);
         GUIItem arrow = new GUIItem(Material.ARROW).displayName(ChatColor.GRAY + "Owl Arrows").amount(32);
 
         player.getInventory().setItem(0, blade.build());
@@ -49,11 +57,12 @@ public class ScoutKit extends Kit {
         ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta helMeta = (LeatherArmorMeta) helmet.getItemMeta();
         helMeta.setColor(Color.YELLOW);
+        helMeta.setUnbreakable(true);
         helmet.setItemMeta(helMeta);
         player.getInventory().setHelmet(helmet);
 
-        player.getInventory().setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
-        player.getInventory().setLeggings(new ItemStack(Material.LEATHER_LEGGINGS));
-        player.getInventory().setBoots(new ItemStack(Material.LEATHER_BOOTS));
+        player.getInventory().setChestplate(new GUIItem(Material.LEATHER_CHESTPLATE).unbreakable(true).build());
+        player.getInventory().setLeggings(new GUIItem(Material.LEATHER_LEGGINGS).unbreakable(true).build());
+        player.getInventory().setBoots(new GUIItem(Material.LEATHER_BOOTS).unbreakable(true).build());
     }
 }

--- a/src/main/java/uk/hotten/herobrine/kit/kits/SorcererKit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/kits/SorcererKit.java
@@ -13,6 +13,7 @@ import uk.hotten.herobrine.kit.abilities.HarmingTotemAbility;
 import uk.hotten.herobrine.kit.abilities.HealingTotemAbility;
 import uk.hotten.herobrine.kit.abilities.LocatorAbility;
 import uk.hotten.herobrine.kit.abilities.WooflessAbility;
+import uk.hotten.herobrine.utils.Message;
 
 public class SorcererKit extends Kit {
 
@@ -22,7 +23,20 @@ public class SorcererKit extends Kit {
                 ChatColor.RED + "Sorcerer",
                 "theherobrine.kit.unlockable.sorcerer",
                 requirePermission,
-                "",
+                Message.createArray(
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Axe of Death" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (weapon)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.AQUA + "Summon Woofless" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x1)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "It's dangerous to go alone, take a friend!",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.YELLOW + ChatColor.BOLD + "Totem: " + ChatColor.GREEN + "Healing" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x1)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Creates an aura of health to heal",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "survivors for 60 seconds",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.YELLOW + ChatColor.BOLD + "Totem: " + ChatColor.RED + "Pain" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x1)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Creates an aura of pain to damage",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "The Herobrine for 60 seconds"
+                ),
                 new GUIItem(Material.GOLDEN_BOOTS).displayName(ChatColor.RED + "Sorcerer")
         );
     }
@@ -37,7 +51,7 @@ public class SorcererKit extends Kit {
 
     @Override
     public void setupPlayer(Player player) {
-        GUIItem axe = new GUIItem(Material.IRON_AXE).displayName(ChatColor.GREEN + "Axe of Death");
+        GUIItem axe = new GUIItem(Material.IRON_AXE).displayName(ChatColor.GREEN + "Axe of Death").unbreakable(true);
 
         player.getInventory().setItem(0, axe.build());
 
@@ -45,11 +59,12 @@ public class SorcererKit extends Kit {
         ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta helMeta = (LeatherArmorMeta) helmet.getItemMeta();
         helMeta.setColor(Color.RED);
+        helMeta.setUnbreakable(true);
         helmet.setItemMeta(helMeta);
         player.getInventory().setHelmet(helmet);
 
-        player.getInventory().setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
-        player.getInventory().setLeggings(new ItemStack(Material.LEATHER_LEGGINGS));
-        player.getInventory().setBoots(new ItemStack(Material.GOLDEN_BOOTS));
+        player.getInventory().setChestplate(new GUIItem(Material.LEATHER_CHESTPLATE).unbreakable(true).build());
+        player.getInventory().setLeggings(new GUIItem(Material.LEATHER_LEGGINGS).unbreakable(true).build());
+        player.getInventory().setBoots(new GUIItem(Material.GOLDEN_BOOTS).unbreakable(true).build());
     }
 }

--- a/src/main/java/uk/hotten/herobrine/kit/kits/WizardKit.java
+++ b/src/main/java/uk/hotten/herobrine/kit/kits/WizardKit.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
+import uk.hotten.herobrine.utils.Message;
 
 public class WizardKit extends Kit {
 
@@ -23,7 +24,15 @@ public class WizardKit extends Kit {
                 ChatColor.DARK_PURPLE + "Wizard",
                 "theherobrine.kit.classic.wizzard",
                 requirePermission,
-                "",
+                Message.createArray(
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Blade of Heroism" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (weapon)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Elixir: Speed" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x1)",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Elixir: Strength" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x1)",
+                        "",
+                        ChatColor.DARK_GRAY + "- " + ChatColor.GREEN + "Dreamweaver Bandage" + ChatColor.DARK_GRAY + ChatColor.ITALIC + " (x2)",
+                        "   " + ChatColor.GRAY + ChatColor.ITALIC + "Bandage yourself to full health"
+                ),
                 new GUIItem(Material.SPLASH_POTION).displayName(ChatColor.DARK_PURPLE + "Wizard"));
     }
 
@@ -36,7 +45,7 @@ public class WizardKit extends Kit {
     @Override
     public void setupPlayer(Player player) {
         // Items
-        GUIItem blade = new GUIItem(Material.STONE_SWORD).displayName(ChatColor.GREEN + "Blade of Heroism");
+        GUIItem blade = new GUIItem(Material.STONE_SWORD).displayName(ChatColor.GREEN + "Blade of Heroism").unbreakable(true);
 
         ItemStack swift = new ItemStack(Material.SPLASH_POTION);
         PotionMeta pmSwift = (PotionMeta) swift.getItemMeta();
@@ -58,11 +67,12 @@ public class WizardKit extends Kit {
         ItemStack helmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta helMeta = (LeatherArmorMeta) helmet.getItemMeta();
         helMeta.setColor(Color.PURPLE);
+        helMeta.setUnbreakable(true);
         helmet.setItemMeta(helMeta);
         player.getInventory().setHelmet(helmet);
         
-        player.getInventory().setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
-        player.getInventory().setLeggings(new ItemStack(Material.LEATHER_LEGGINGS));
-        player.getInventory().setBoots(new ItemStack(Material.LEATHER_BOOTS));
+        player.getInventory().setChestplate(new GUIItem(Material.LEATHER_CHESTPLATE).unbreakable(true).build());
+        player.getInventory().setLeggings(new GUIItem(Material.LEATHER_LEGGINGS).unbreakable(true).build());
+        player.getInventory().setBoots(new GUIItem(Material.LEATHER_BOOTS).unbreakable(true).build());
     }
 }

--- a/src/main/java/uk/hotten/herobrine/utils/Message.java
+++ b/src/main/java/uk/hotten/herobrine/utils/Message.java
@@ -4,6 +4,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
 public class Message {
 
     public static String format(String body) {
@@ -38,6 +43,38 @@ public class Message {
             return (m < 10 ? "0" + m : "" + m) + ":" + (s < 10 ? "0" + s : "" + s);
         else
             return (h < 10 ? "0" + h : "" + h) + ":" + (m < 10 ? "0" + m : "" + m) + ":" + (s < 10 ? "0" + s : "" + s);
+    }
+
+    public static ArrayList<String> createArray(String... lines) {
+        return new ArrayList<>(Arrays.asList(lines));
+    }
+
+    public static ArrayList<String> addLinebreaks(String input, String toAppendAfterNewline) {
+        return addLinebreaks(input, 20, toAppendAfterNewline);
+    }
+
+    public static ArrayList<String> addLinebreaks(String input, int maxLineLength, String toAppendAfterNewline) {
+        ArrayList<String> result = new ArrayList<>();
+
+        StringTokenizer tok = new StringTokenizer(input, " ");
+        StringBuilder output = new StringBuilder();
+        output.insert(0, toAppendAfterNewline);
+        int lineLen = 0;
+        while (tok.hasMoreTokens()) {
+            String word = tok.nextToken();
+
+            if (lineLen + word.length() > maxLineLength) {
+                result.add(output.toString());
+                output = new StringBuilder();
+                output.append(toAppendAfterNewline);
+                lineLen = 0;
+            }
+            output.append(word).append(" ");
+            lineLen += word.length();
+        }
+        result.add(output.toString());
+
+        return result;
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: TheHerobrine-OG
 main: uk.hotten.herobrine.HerobrinePluginOG
-version: 1.2
+version: 1.3
 api-version: 1.18
 author: Gxorge
 description: Remake of "The Herobrine!" v2 from HiveMC.
@@ -23,6 +23,12 @@ commands:
     permission: theherobrine.command.dropshard
     usage: /<command>
 
+  pausetimer:
+    description: Pause the start timer.
+    permission: theherobrine.command.pausetimer
+    usage: /<command>
+
   vote:
     description: Vote for a map.
     usage: /<command> <map number>
+    aliases: [v]


### PR DESCRIPTION
Version 1.3 has the following new features and bug fixes:

Game Manager
- /pausetimer to pause the start time from running
- /vote now has a /v alias
- Put the start check logic into its own function
- Changed HB's smoke to the same as the OG game
- All Herobrine items are now unbreakable
- End check can longer end the game if it isn't LIVE (in rare instances where the last survivor killed HB and HB killed them at the same time, the game would end twice) 

Voting
- Fixed a grammatical error in the vote confirmation

Kits
- All kit items now have descriptions on how they work
- Kit GUI shows each kit item and what they do
- Changed the colour of the kit GUI's text
- Changed the colour of the Totem of Pain's "Pain" from green to red
- Protection spirit no longer breaks spectator mode if a player dies with it active
- All kit items are now unbreakable